### PR TITLE
Make typeID consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,28 +85,28 @@ The RTU backend pre-defines these functions:
         with the same coa and stored relation-ship.
     - raises a `RuntimeError` if an invalid relationship is found
         
-4.  `_invalid_typeID(self, coa: COA, ioa: IOA, typeID: int) -> Union[bool, None, int]`
-     - checks if the typeID-argument and the datapoint's default typeID are command-query typeIDs (in [45,69])
-     - if True, returns `defaultTypeID == typeID` 
+4.  `_invalid_type_id(self, coa: COA, ioa: IOA, type_id: int) -> Union[bool, None, int]`
+     - checks if the type_id-argument and the datapoint's default type_id are command-query type_ids (in [45,69])
+     - if True, returns `defaulttype_id == type_id` 
      - reasoning: restrict allowed command-queries to those specified by the datapoint
      - returns `None` for unattached datapoint
-     - returns `0` if either the handed over typeID or the typeID stored for the datapoint
-        are not command-query-typeIDs 
+     - returns `0` if either the handed over type_id or the type_id stored for the datapoint
+        are not command-query-type_ids 
         
-5. `get_IO(self, coa: COA, ioa: IOA, cot: int=0, typeID: int=0) -> Any`
+5. `get_IO(self, coa: COA, ioa: IOA, cot: int=0, type_id: int=0) -> Any`
     - retrieve the IO based on the coa-ioa combination
     - returns `None` if the RTU has no such datapoint with a resp. IO attached to it or
-        a typeID != 0 is given and which is invalid for this datapoint
+        a type_id != 0 is given and which is invalid for this datapoint
     - if `cot==0`, chooses default cot stored
 
 6. `has_IO(self, coa: COA, ioa: IOA) -> bool`
     - check if an IO with the given coa-ioa combination is attached to the RTU
 
-7. `set_IO(self, coa: COA, ioa: IOA, value, cot: int=0, typeID: int=0) -> Union[bool, None]`
+7. `set_IO(self, coa: COA, ioa: IOA, value, cot: int=0, type_id: int=0) -> Union[bool, None]`
     - sets an IO on a datapoint
     - if `cot==0` build query with default cot
     - returns the model-dependent query response for attached datapoints and
-        `None` if the RTU does not know such an IO or typeID is given which is not valid for this datapoint
+        `None` if the RTU does not know such an IO or type_id is given which is not valid for this datapoint
          - resulting limitation: cannot differentiate between the return of a `None` query response and a 
             non-attached IO
 
@@ -205,8 +205,8 @@ The interface logs the following data:
     - sending the query for `set_IO`, `get_IO`, or or its related-datapoint versions on an attached datapoint failed for some other 
         reason
     - changing the cot for an unattached datapoint or trying to set it to an invalid value
-    - trying to set/get IOs with an invalid typeID for the given datapoint or if the corresponding
-        IO does not lie in the IEC104-range for this typeID
+    - trying to set/get IOs with an invalid type_id for the given datapoint or if the corresponding
+        IO does not lie in the IEC104-range for this type_id
 3. `INFO`
     - whenever the `self.started` status changes
     - time [s] it took to setup a client (if applicable)

--- a/wattson_abstract_rtu/backend_interface.py
+++ b/wattson_abstract_rtu/backend_interface.py
@@ -2,7 +2,7 @@ import abc
 from typing import Union, Tuple, Any, Iterable, Set, Optional, Callable
 from threading import Event
 
-from .util import COA, IOA, control_direction_processinfo_typeIDs, typeID_to_permitted_IOs, \
+from .util import COA, IOA, control_direction_processinfo_type_ids, type_id_to_permitted_IOs, \
     sink_logger
 
 
@@ -83,25 +83,25 @@ class BackendInterface(abc.ABC):
         if autostart:
             self.wait_until_ready()
 
-    def get_IO(self, coa: COA, ioa: IOA, cot: int = 0, typeID: int = 0):
+    def get_IO(self, coa: COA, ioa: IOA, cot: int = 0, type_id: int = 0):
         """
         Retrieves the IO from an attached datapoint.
         :param coa: The COA for the requested Information Object
         :param ioa: The IOA for the requested Information Object
         :param cot: 0 -> choose default value initialised with
-        :param typeID: != 0 -> check if returned IO is equal to allowed IOs for this ASDU typeID
-        :return: None if the datapoint is not attached or the typeID doesn't match the expected
+        :param type_id: != 0 -> check if returned IO is equal to allowed IOs for this ASDU type_id
+        :return: None if the datapoint is not attached or the type_id doesn't match the expected
             for a datapoint, otherwise query result
         """
         if not self.has_IO(coa, ioa):
             self.logger.warning(f"tried to get IO for unattached datapoint with ioa {ioa} and coa {coa}")
             return None
 
-        if not self._valid_typeID(coa, ioa, typeID):
-            stored_typeID = self.get_data_point(coa, ioa)[2]
+        if not self._valid_type_id(coa, ioa, type_id):
+            stored_type_id = self.get_data_point(coa, ioa)[2]
             self.logger.warning(f"Tried sending a get-IO query with invalid command-query-ID "
-                                f"{typeID} to dp with (coa, ioa) ({coa}, {ioa})."
-                                f" Expecting typeID {stored_typeID} for command-queries to this dp."
+                                f"{type_id} to dp with (coa, ioa) ({coa}, {ioa})."
+                                f" Expecting type_id {stored_type_id} for command-queries to this dp."
                                 f" Not sending this query.")
             return None
 
@@ -111,13 +111,13 @@ class BackendInterface(abc.ABC):
         if res is None:
             self.logger.warning(f"Retrieving IO for attached datapoint with (coa, ioa, cot) "
                                  f"({coa}, {ioa}, {cot}) failed!")
-        elif typeID in typeID_to_permitted_IOs \
-                and res not in typeID_to_permitted_IOs[typeID]:
-            # default typeID 0 not allowed for ASDUs -> never in type_ID_to...
+        elif type_id in type_id_to_permitted_IOs \
+                and res not in type_id_to_permitted_IOs[type_id]:
+            # default type_id 0 not allowed for ASDUs -> never in type_ID_to...
 
             self.logger.warning(f"Retrieved IO with invalid value {res} "
-                                    f"for typeID {typeID} from dp with (coa, ioa) ({coa}, {ioa})."
-                                    f"Expecting value in {typeID_to_permitted_IOs[typeID]}.")
+                                    f"for type_id {type_id} from dp with (coa, ioa) ({coa}, {ioa})."
+                                    f"Expecting value in {type_id_to_permitted_IOs[type_id]}.")
         else:
             self.logger.debug(f"Send query {query} to datapoint with (coa, ioa, cot): "
                               f"({coa}, {ioa}, {cot}) and result {res}")
@@ -126,18 +126,18 @@ class BackendInterface(abc.ABC):
     def has_IO(self, coa: COA, ioa: IOA) -> bool:
         return coa in self.data_store and ioa in self.data_store[coa]
 
-    def set_IO(self, coa: COA, ioa: IOA, value, cot: int=0, typeID: int=0) -> Union[bool, None]:
+    def set_IO(self, coa: COA, ioa: IOA, value, cot: int=0, type_id: int=0) -> Union[bool, None]:
         """
         Overwrites IO on an attached datapoint.
         :param coa: The COA for the Information Object to be set
         :param ioa: The IOA for the Information Object to be set
         :param cot: if 0, send query with cot this datapoint was initialised with
-        :param typeID: if != 0 & command-query-typeID, check if this typeID is allowed
+        :param type_id: if != 0 & command-query-type_id, check if this type_id is allowed
                 fot this dp.
         :return: None if datapoint identified by coa-ioa is not attached to this RTU
-                or the typeID is not allowed for this datapoint,
+                or the type_id is not allowed for this datapoint,
                 True/False depending on success of sending the query.
-        Allows, but logs warning if an dp is set to a value invalid for this typeID
+        Allows, but logs warning if an dp is set to a value invalid for this type_id
         """
 
         if not self.has_IO(coa, ioa):
@@ -147,20 +147,20 @@ class BackendInterface(abc.ABC):
         stored_cot = self.get_data_point(coa, ioa)[3]
         if cot == 0:
             cot = stored_cot
-        if not self._valid_typeID(coa, ioa, typeID):
-            stored_typeID = self.get_data_point(coa, ioa)[2]
-            self.logger.warning(f"Tried to send a set-IO query with invalid command-query-typeID "
-                                f"{typeID} to dp with (coa, ioa) ({coa}, {ioa})."
-                                f"Expecting typeID {stored_typeID} for command-queries to this dp."
+        if not self._valid_type_id(coa, ioa, type_id):
+            stored_type_id = self.get_data_point(coa, ioa)[2]
+            self.logger.warning(f"Tried to send a set-IO query with invalid command-query-type_id "
+                                f"{type_id} to dp with (coa, ioa) ({coa}, {ioa})."
+                                f"Expecting type_id {stored_type_id} for command-queries to this dp."
                                 f"Not sending the query.")
-            # only allow queries if they have the typeID dp allows just this command
+            # only allow queries if they have the type_id dp allows just this command
             return None
 
-        if typeID in typeID_to_permitted_IOs \
-                and value not in typeID_to_permitted_IOs[typeID]:
+        if type_id in type_id_to_permitted_IOs \
+                and value not in type_id_to_permitted_IOs[type_id]:
             self.logger.warning(f"Sending a set-IO query to with invalid value {value} "
-                                f"for typeID {typeID} to dp with (coa, ioa) ({coa}, {ioa})."
-                                f"Expecting value in {typeID_to_permitted_IOs[typeID]}.")
+                                f"for type_id {type_id} to dp with (coa, ioa) ({coa}, {ioa})."
+                                f"Expecting value in {type_id_to_permitted_IOs[type_id]}.")
 
         query = self._build_IO_query(coa, ioa, cot, value)
         res = self._send_query(query)
@@ -172,23 +172,23 @@ class BackendInterface(abc.ABC):
                              f"({coa}, {ioa}, {cot}) failed!")
         return res
 
-    def set_related_IO(self, coa: COA, ioa: IOA, cot: int=0, typeID: int=0) -> Union[bool, None]:
+    def set_related_IO(self, coa: COA, ioa: IOA, cot: int=0, type_id: int=0) -> Union[bool, None]:
         """Sets the IO related to the coa-ioa identified datapoint."""
         if not self.has_IO(coa, ioa):
             self.logger.warning(f"cannot set related IO from non-attached dp with (coa, ioa)"
                                 f"({coa}, {ioa})")
         # relationships were sanitised before; related dp has to be attached
         related_dp = self.get_related_data_point(coa, ioa)
-        return self.set_IO(related_dp[0], related_dp[1], cot, typeID)
+        return self.set_IO(related_dp[0], related_dp[1], cot, type_id)
 
-    def get_related_IO(self, coa: COA, ioa: IOA, cot: int=0, typeID: int=0) -> Union[bool, None]:
+    def get_related_IO(self, coa: COA, ioa: IOA, cot: int=0, type_id: int=0) -> Union[bool, None]:
         """Gets the IO related to the coa-ioa identified datapoint."""
         if not self.has_IO(coa, ioa):
             self.logger.warning(f"cannot read related IO from non-attached dp with (coa, ioa)"
                                 f"({coa}, {ioa})")
         # relationships were sanitised before; related dp has to be attached
         related_dp = self.get_related_data_point(coa, ioa)
-        return self.get_IO(related_dp[0], related_dp[1], cot, typeID)
+        return self.get_IO(related_dp[0], related_dp[1], cot, type_id)
 
     def get_data_point(self, coa: COA, ioa: IOA, with_value=False) -> \
             Union[None, Tuple, Tuple[Tuple, Any]]:
@@ -331,21 +331,21 @@ class BackendInterface(abc.ABC):
                 return False
         return True
 
-    def _valid_typeID(self, coa: COA, ioa: IOA, typeID: int) -> Union[bool, None, int]:
+    def _valid_type_id(self, coa: COA, ioa: IOA, type_id: int) -> Union[bool, None, int]:
         """
         :return:
             None: dp not attached to RTU
-            0: typeID handed over or stored for the dp not a command-query-typeID (45-69)
-            True: typeID and stored dp-typeID equal command-query-typeID
-            False: typeID and stored dp-typeID unequal command-query-typeID
+            0: type_id handed over or stored for the dp not a command-query-type_id (45-69)
+            True: type_id and stored dp-type_id equal command-query-type_id
+            False: type_id and stored dp-type_id unequal command-query-type_id
         if a command query with the given cot is allowed for this datapoint
         """
         dp = self.get_data_point(coa, ioa)
         if dp is None:
             return None
-        if dp[2] in control_direction_processinfo_typeIDs \
-            and typeID in control_direction_processinfo_typeIDs:
-            return dp[2] == typeID
+        if dp[2] in control_direction_processinfo_type_ids \
+            and type_id in control_direction_processinfo_type_ids:
+            return dp[2] == type_id
         return True
 
 

--- a/wattson_abstract_rtu/backend_interface.py
+++ b/wattson_abstract_rtu/backend_interface.py
@@ -83,13 +83,13 @@ class BackendInterface(abc.ABC):
         if autostart:
             self.wait_until_ready()
 
-    def get_IO(self, coa: COA, ioa: IOA, cot: int = 0, type_id: int = 0):
+    def get_IO(self, coa: COA, ioa: IOA, cot: int = 0, typeID: int = 0):
         """
         Retrieves the IO from an attached datapoint.
         :param coa: The COA for the requested Information Object
         :param ioa: The IOA for the requested Information Object
         :param cot: 0 -> choose default value initialised with
-        :param type_id: != 0 -> check if returned IO is equal to allowed IOs for this ASDU typeID
+        :param typeID: != 0 -> check if returned IO is equal to allowed IOs for this ASDU typeID
         :return: None if the datapoint is not attached or the typeID doesn't match the expected
             for a datapoint, otherwise query result
         """
@@ -97,11 +97,11 @@ class BackendInterface(abc.ABC):
             self.logger.warning(f"tried to get IO for unattached datapoint with ioa {ioa} and coa {coa}")
             return None
 
-        if not self._valid_typeID(coa, ioa, type_id):
+        if not self._valid_typeID(coa, ioa, typeID):
             stored_typeID = self.get_data_point(coa, ioa)[2]
             self.logger.warning(f"Tried sending a get-IO query with invalid command-query-ID "
-                                f"{type_id} to dp with (coa, ioa) ({coa}, {ioa})."
-                                f" Expecting type_id {stored_typeID} for command-queries to this dp."
+                                f"{typeID} to dp with (coa, ioa) ({coa}, {ioa})."
+                                f" Expecting typeID {stored_typeID} for command-queries to this dp."
                                 f" Not sending this query.")
             return None
 
@@ -111,13 +111,13 @@ class BackendInterface(abc.ABC):
         if res is None:
             self.logger.warning(f"Retrieving IO for attached datapoint with (coa, ioa, cot) "
                                  f"({coa}, {ioa}, {cot}) failed!")
-        elif type_id in typeID_to_permitted_IOs \
-                and res not in typeID_to_permitted_IOs[type_id]:
-            # default type_id 0 not allowed for ASDUs -> never in type_ID_to...
+        elif typeID in typeID_to_permitted_IOs \
+                and res not in typeID_to_permitted_IOs[typeID]:
+            # default typeID 0 not allowed for ASDUs -> never in type_ID_to...
 
             self.logger.warning(f"Retrieved IO with invalid value {res} "
-                                    f"for type_id {type_id} from dp with (coa, ioa) ({coa}, {ioa})."
-                                    f"Expecting value in {typeID_to_permitted_IOs[type_id]}.")
+                                    f"for typeID {typeID} from dp with (coa, ioa) ({coa}, {ioa})."
+                                    f"Expecting value in {typeID_to_permitted_IOs[typeID]}.")
         else:
             self.logger.debug(f"Send query {query} to datapoint with (coa, ioa, cot): "
                               f"({coa}, {ioa}, {cot}) and result {res}")
@@ -132,12 +132,12 @@ class BackendInterface(abc.ABC):
         :param coa: The COA for the Information Object to be set
         :param ioa: The IOA for the Information Object to be set
         :param cot: if 0, send query with cot this datapoint was initialised with
-        :param typeID: if != 0 & command-query-type_id, check if this type_id is allowed
+        :param typeID: if != 0 & command-query-typeID, check if this typeID is allowed
                 fot this dp.
         :return: None if datapoint identified by coa-ioa is not attached to this RTU
-                or the type_id is not allowed for this datapoint,
+                or the typeID is not allowed for this datapoint,
                 True/False depending on success of sending the query.
-        Allows, but logs warning if an dp is set to a value invalid for this type_id
+        Allows, but logs warning if an dp is set to a value invalid for this typeID
         """
 
         if not self.has_IO(coa, ioa):
@@ -149,17 +149,17 @@ class BackendInterface(abc.ABC):
             cot = stored_cot
         if not self._valid_typeID(coa, ioa, typeID):
             stored_typeID = self.get_data_point(coa, ioa)[2]
-            self.logger.warning(f"Tried to send a set-IO query with invalid command-query-type_id "
+            self.logger.warning(f"Tried to send a set-IO query with invalid command-query-typeID "
                                 f"{typeID} to dp with (coa, ioa) ({coa}, {ioa})."
-                                f"Expecting type_id {stored_typeID} for command-queries to this dp."
+                                f"Expecting typeID {stored_typeID} for command-queries to this dp."
                                 f"Not sending the query.")
-            # only allow queries if they have the type_id dp allows just this command
+            # only allow queries if they have the typeID dp allows just this command
             return None
 
         if typeID in typeID_to_permitted_IOs \
                 and value not in typeID_to_permitted_IOs[typeID]:
             self.logger.warning(f"Sending a set-IO query to with invalid value {value} "
-                                f"for type_id {typeID} to dp with (coa, ioa) ({coa}, {ioa})."
+                                f"for typeID {typeID} to dp with (coa, ioa) ({coa}, {ioa})."
                                 f"Expecting value in {typeID_to_permitted_IOs[typeID]}.")
 
         query = self._build_IO_query(coa, ioa, cot, value)
@@ -335,9 +335,9 @@ class BackendInterface(abc.ABC):
         """
         :return:
             None: dp not attached to RTU
-            0: type_id handed over or stored for the dp not a command-query-type_id (45-69)
-            True: type_id and stored dp-type_id equal command-query-type_id
-            False: type_id and stored dp-type_id unequal command-query-type_id
+            0: typeID handed over or stored for the dp not a command-query-typeID (45-69)
+            True: typeID and stored dp-typeID equal command-query-typeID
+            False: typeID and stored dp-typeID unequal command-query-typeID
         if a command query with the given cot is allowed for this datapoint
         """
         dp = self.get_data_point(coa, ioa)

--- a/wattson_abstract_rtu/util.py
+++ b/wattson_abstract_rtu/util.py
@@ -2,7 +2,7 @@ from typing import Union
 COA = Union[int, str]
 IOA = Union[int, str]
 
-control_direction_processinfo_typeIDs = range(45,70)
+control_direction_processinfo_type_ids = range(45,70)
 
 def check_pkg(name):
     from pip._internal.utils.misc import get_installed_distributions
@@ -12,7 +12,7 @@ def check_pkg(name):
 FCS_installed = check_pkg("FCS")
 
 # key = ASDU type ID; value = permitted IO values set to/ returned
-typeID_to_permitted_IOs  = {
+type_id_to_permitted_IOs  = {
     1: (0, 1),
     2: (0, 1),
     30: (0, 1),


### PR DESCRIPTION
We should decide whether it's `type_id` or `typeID`.

It gets very confusing when some functions expect a type_id and others a `typeID` keyword argument.

This PR changes all `type_id` instances to `typeID`, as it required less code changes.